### PR TITLE
refactor: drop support for ansible 2.9 and 2.10

### DIFF
--- a/{{ cookiecutter.project_slug }}/requirements.yml
+++ b/{{ cookiecutter.project_slug }}/requirements.yml
@@ -2,6 +2,7 @@
 roles:
   - name: jonaspammer.bootstrap
 #  - name: jonaspammer.core_dependencies
+
+# NOTE: list all collections used here (even if included in `ansible`)
 collections:
-  - name: community.docker # only needed for molecule execution
   - name: community.general

--- a/{{ cookiecutter.project_slug }}/tox.ini
+++ b/{{ cookiecutter.project_slug }}/tox.ini
@@ -7,7 +7,7 @@ extend-ignore = E203
 ### Ansible Testing through Molecule ###
 [tox]
 minversion = 3.21.4
-envlist = pre-commit,py{3}-ansible-{2.9,2.10,2.11,2.12}
+envlist = pre-commit,py{3}-ansible-{4,5}
 
 skipsdist = true
 
@@ -15,12 +15,10 @@ skipsdist = true
 passenv = *
 parallel_show_output = True
 deps =
-    2.9: ansible == 2.9.*
-    2.10: ansible-base == 2.10.*
-    2.11: ansible-core == 2.11.*
-    2.12: ansible-core == 2.12.*
+    4: ansible == 4.* # core 2.11 + https://github.com/ansible-community/ansible-build-data/blob/main/4/ansible-4.build
+    5: ansible == 5.* # core 2.12 + https://github.com/ansible-community/ansible-build-data/blob/main/5/ansible-5.build
     molecule[docker]
-    docker == 4.*
+    docker == 5.*
 commands =
     ansible --version
     molecule destroy


### PR DESCRIPTION
Fixes #11 

Tested as per https://github.com/JonasPammer/ansible-role-bootstrap/pull/51