### PR TITLE
ci: add workflow dispatch option for defining ansible version for debug tox run

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -25,6 +25,16 @@ permissions: read-all
           - ubuntu1604
           - ubuntu1804
           - ubuntu2004
+      ansible_version:
+        description: "Select Ansible Versions to run"
+        required: false
+        type: choice
+        default: "ansible-5,ansible-4"
+        options:
+          - ansible-5,ansible-4
+          - ansible-4,ansible-5
+          - ansible-4
+          - ansible-5
   pull_request:
   push:
     branches:
@@ -140,6 +150,7 @@ jobs:
       - name: Run Molecule tests (debug).
         run: tox
         env:
+          TOXENV: py3-${{ github.event.inputs.ansible_version }}
           TOX_SKIP_ENV: pre-commit
           TOX_PARALLEL_NO_SPINNER: 1
           MOLECULE_DISTRO: {% raw %}${{ matrix.distro }}{% endraw %}


### PR DESCRIPTION
as per Proof of Concept implemented in https://github.com/JonasPammer/ansible-role-bootstrap/pull/55