### PR TITLE
refactor: install pip, dev dependencies, pre-commit hooks and bash-it in devcontainer dockerfile

### DIFF
--- a/{{ cookiecutter.project_slug }}/.devcontainer/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/.devcontainer/Dockerfile
@@ -38,13 +38,34 @@ CMD [ "sleep", "infinity" ]
 
 ########################
 ### OWN INSTRUCTIONS ###
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends python3 python3-pip python3-setuptools \
-    && python3 -m pip install --upgrade pip && python3 -m pip install tox
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get -qy update \
+    && apt-get -qy upgrade \
+    && apt-get -qy install --no-install-recommends apt-utils tini \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install shellcheck script to system as needed by pre-commit hook
-ADD https://github.com/koalaman/shellcheck/releases/download/v0.8.0/shellcheck-v0.8.0.linux.x86_64.tar.xz /tmp/shellcheck
-RUN apt-get -y install --no-install-recommends xz-utils \
-    && mkdir -p /tmp/shellcheckd \
-    && tar -xJf /tmp/shellcheck --directory /tmp/shellcheckd \
-    && cp /tmp/shellcheckd/shellcheck-v0.8.0/shellcheck /usr/local/bin/
+RUN apt-get -qy update \
+    && apt-get -qqy install --no-install-recommends python3-pip python3-wheel \
+    && python3 -m pip install --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir wheel \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+USER vscode
+RUN git clone --depth=1 https://github.com/Bash-it/bash-it.git /home/vscode/.bash_it && \
+    /home/vscode/.bash_it/install.sh --overwrite-backup --silent
+# `bash-it` is a function. need to go into interactive mode of before-defined USER!
+SHELL ["/bin/bash", "-ic"]
+RUN bash-it enable alias apt bash-it curl docker fuck general git systemd && \
+    bash-it enable completion bash-it defaults dirs docker git github-cli pip3 pipx ssh system && \
+    bash-it enable plugin alias-completion base colors dirs docker explain extract git gitstatus history history-search man python thefuck z_autoenv
+SHELL ["/bin/bash", "-c"]
+
+COPY postCreateCommand.sh /home/vscode/postCreateCommand.sh
+USER root
+RUN chmod u+x /home/vscode/postCreateCommand.sh
+
+USER vscode

--- a/{{ cookiecutter.project_slug }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.project_slug }}/.devcontainer/devcontainer.json
@@ -11,27 +11,28 @@
   "settings": {},
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": [
+    // ## General / GUI ##
+    "eamodio.gitlens",
+    "donjayamanne.githistory",
+    "mhutchie.git-graph",
+    "Gruntfuggly.todo-tree",
+    "aaron-bond.better-comments",
+    "asciidoctor.asciidoctor-vscode",
+    "ms-azuretools.vscode-docker",
+    "mutantdino.resourcemonitor",
+
     // ## Ansible Development ##
     "redhat.ansible",
     "redhat.vscode-yaml",
     "wholroyd.jinja",
-    "samuelcolvin.jinjahtml",
-
-    // ## General ##
-    "ms-azuretools.vscode-docker",
-    "asciidoctor.asciidoctor-vscode",
-    "Gruntfuggly.todo-tree",
-    "eamodio.gitlens",
-    "donjayamanne.githistory",
-    "mhutchie.git-graph"
-    // "mutantdino.resourcemonitor"
+    "samuelcolvin.jinjahtml"
   ],
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  // "postCreateCommand": "docker --version",
+  "postCreateCommand": "/bin/bash -ic 'source /home/vscode/postCreateCommand.sh'",
 
   // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode",

--- a/{{ cookiecutter.project_slug }}/.devcontainer/postCreateCommand.sh
+++ b/{{ cookiecutter.project_slug }}/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+python3 -m pip install -r requirements-dev.txt
+
+pre-commit install --install-hooks
+#pre-commit install --hook-type commit-msg


### PR DESCRIPTION
as per POC implemented in https://github.com/JonasPammer/ansible-role-bootstrap/pull/56/files

note that `pre-commit install --hook-type commit-msg` was commented out because
it resulted in one of the  hooks (prettier iirc) to act on commit-msg too which ended up blocking ofc