### PR TITLE
ci: generate README.md as part of gh-pages.yml for use in galaxy

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/gh-pages.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/gh-pages.yml
@@ -1,5 +1,5 @@
 ---
-name: build self-contained README
+name: build self-contained READMEs
 
 "on":
   push:
@@ -22,23 +22,47 @@ jobs:
         with:
           ruby-version: "2.7.0"
 
-      - name: install asciidoctor
+      - name: set up python 3
+        uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # tag=v4
+        with:
+          python-version: "3.x"
+
+      - name: setup/activate pre-commit cache
+        uses: actions/cache@f4278025ab0f432ce369118909e46deec636f50c # tag=v3
+        with:
+          path: ~/.cache/pre-commit
+          key: "{% raw %}${{ hashFiles('.pre-commit-config.yaml') }}{% endraw %}"
+
+      - name: install asciidoctor and other relevant ruby gems
         run: gem install --no-document asciidoctor asciidoctor-reducer rouge coderay
 
       - name: Generate README.adoc using ascidoctor-reducer.
         run: asciidoctor-reducer README.orig.adoc -o README.adoc
 
+      - name: generate README.xml from README.adoc using ascidoctor
+        run: asciidoctor -b docbook README.adoc
+
+      - name: Generate README.md from README.xml using pandoc
+        uses: docker://pandoc/core@sha256:65d98a5fb89867961479c16f4597134517923661aca23ef63843f6b6e623508b
+        with:
+          args: "-f docbook -t markdown_strict README.xml -o README.md"
+
+      - name: pre-commit README.md
+        run: |
+          python3 -m pip install pre-commit
+          pre-commit run --files README.md || true
+
       - name: Commit generated README.
         uses: stefanzweifel/git-auto-commit-action@49620cd3ed21ee620a48530e81dba0d139c9cb80 # tag=v4
         with:
           commit_message: "{% raw %}${{ github.event.head_commit.message }} {% endraw %} \n as per {% raw %}${{ github.sha }}{% endraw %}"
-          file_pattern: README.adoc
+          file_pattern: README.adoc README.md
           disable_globbing: true
 
       - name: Generate HTML
         run: asciidoctor --backend=html5 --destination-dir docs --out-file index.html README.adoc
 
-      - name: Deploy to GitHub Pages (when branch is master)
+      - name: Deploy HTML to GitHub Pages (when branch is master)
         uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305 # tag=v3
         with:
           github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}

--- a/{{ cookiecutter.project_slug }}/.gitignore
+++ b/{{ cookiecutter.project_slug }}/.gitignore
@@ -1,3 +1,5 @@
+README.xml
+
 # Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode,jetbrains+all,virtualenv,linux,svn,windows,python,ansible
 # Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode,jetbrains+all,virtualenv,linux,svn,windows,python,ansible
 


### PR DESCRIPTION
Closes #38 

Copied implementation from https://github.com/JonasPammer/cookiecutter-pypackage/blob/master/%7B%7B%20cookiecutter.project_slug%20%7D%7D/.github/workflows/gh-pages.yml (commit blame in question: https://github.com/JonasPammer/cookiecutter-pypackage/pull/17/commits/bcf5e86bb09494ab9201a1c07eaca008cbd04e96)