### PR TITLE
ci: fix 'if this step is .., this is a real/fake run' message

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       {%- endraw %}
 
     steps:
-      - name: If this step is not skipped, this is a FAKE ci run.
+      - name: if this step is run, this is a real ci run
         run: >
           cat << EOF
             If this step is NOT skipped, this workflow run was manually dispatched
@@ -122,7 +122,7 @@ jobs:
             This is a hack because GitHub CI does not allow for a state other than "failed"
             as per https://github.com/actions/runner/issues/662
           EOF
-        if: env.WORKFLOW_DISPATCH_IF == 'false'
+        if: github.event_name != 'workflow_dispatch' || env.WORKFLOW_DISPATCH_IF == 'true'
 
       - name: check out the codebase
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
@@ -147,7 +147,7 @@ jobs:
           TOX_SKIP_ENV: pre-commit
           TOX_PARALLEL_NO_SPINNER: 1
           MOLECULE_DISTRO: {% raw %}${{ matrix.distro }}{% endraw %}
-        if: {% raw %}${{ github.event_name != 'workflow_dispatch' }}{% endraw %}
+        if: github.event_name != 'workflow_dispatch'
 
       - name: Run Molecule tests (debug).
         run: tox


### PR DESCRIPTION
Closes #45

the message was un-confused by flipping the phrasing from "not -> " to "is -> "
the if was fixed by making it be "(if condition of normal tox) || (if condition of debug tox step)"