### PR TITLE
style: "'role' is a required property"

### DIFF
--- a/ROLE_DEVELOPMENT_TIPS.adoc
+++ b/ROLE_DEVELOPMENT_TIPS.adoc
@@ -70,12 +70,12 @@ A role should always be more than a single task file.
 ---
 - hosts: webservers
   roles:
-  - name: apache_simple
+  - role: apache_simple
     apache_http_port: 80
     apache_doc_root: /var/www/html
     apache_user: www-data
     apache_group: www-data
-  - name: apache_simple
+  - role: apache_simple
     apache_http_port: 8080
     apache_doc_root: /www/example.com
     apache_user: www-data

--- a/{{ cookiecutter.project_slug }}/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/{{ cookiecutter.project_slug }}/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -34,7 +34,7 @@ body:
           name: Role Test
 
           roles:
-            - {{ cookiecutter.role_name }}
+            - role: {{ cookiecutter.role_name }}
       render: yaml
     validations:
       required: true

--- a/{{ cookiecutter.project_slug }}/README.orig.adoc
+++ b/{{ cookiecutter.project_slug }}/README.orig.adoc
@@ -153,7 +153,7 @@ requirements.yml dependency graph of {{ cookiecutter.galaxy_name }}.{{ cookiecut
 [source,yaml]
 ----
 roles:
-  - {{ cookiecutter.galaxy_name }}.{{ cookiecutter.role_name }}
+  - role: {{ cookiecutter.galaxy_name }}.{{ cookiecutter.role_name }}
 
 vars:
   some_var: "some_value"

--- a/{{ cookiecutter.project_slug }}/molecule/default/converge.yml
+++ b/{{ cookiecutter.project_slug }}/molecule/default/converge.yml
@@ -3,4 +3,4 @@
   hosts: all
 
   roles:
-    - name: "{{ cookiecutter.project_slug }}"
+    - role: "{{ cookiecutter.project_slug }}"

--- a/{{ cookiecutter.project_slug }}/molecule/resources/prepare.yml
+++ b/{{ cookiecutter.project_slug }}/molecule/resources/prepare.yml
@@ -5,5 +5,5 @@
   gather_facts: false
 
   roles:
-    - name: jonaspammer.bootstrap
+    - role: jonaspammer.bootstrap
     #    - name: jonaspammer.core_dependencies


### PR DESCRIPTION
Fixes #80
as trialed in https://github.com/JonasPammer/ansible-role-bootstrap/pull/77

i can swear it works with name too (which is why i was long time confused about this error) but role seems to work too and fixes the ansible-lint so i guess is it's the real one which is why i updated every "roles:" i could strg+find in this project subsequently too