### PR TITLE
docs: denote supported ansible versions in cookie

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,7 @@ rolename__somevar: "{{
 
 === GitHub
 * Includes a Continuous GitHub *Workflow to `yamllint` / `ansiblelint` all files*
-* Includes a Continuous GitHub *Workflow to run `molecule` test's on a matrix of different OS's* (with systemd support) *and Ansible versions*
+* Includes a Continuous GitHub *Workflow to run `molecule` test's on a matrix of different distributions* (with systemd support) *and different Ansible versions*
 * Includes a GitHub *Workflow to release to Ansible Galaxy*
 +
 [NOTE]

--- a/{{ cookiecutter.project_slug }}/DEVELOPMENT.adoc
+++ b/{{ cookiecutter.project_slug }}/DEVELOPMENT.adoc
@@ -46,10 +46,9 @@ takes care of importing the role to my Ansible Galaxy Account.
 === 🧪 Testing
 Automatic Tests are run on each Contribution using GitHub Workflows.
 
-The Tests primarily resolve around running
-https://molecule.readthedocs.io/en/latest/[Molecule]
-on a varying set of linux distributions and using various ansible versions,
-as detailed in https://github.com/{{ cookiecutter.github_username }}/ansible-roles[{{ cookiecutter.github_username }}/ansible-roles].
+The Tests primarily resolve around running https://molecule.readthedocs.io/en/latest/[Molecule]
+on a <<tested-distributions,varying set of linux distributions>>
+and using <<tested-ansible-versions,various ansible versions>>.
 
 The molecule test also includes a step which lints all ansible playbooks using
 https://github.com/ansible/ansible-lint#readme[`ansible-lint`]
@@ -119,6 +118,7 @@ You may also want to know that the files mentioned in the admonition above
 are attached to the *GitHub CI Artifacts* of a given Workflow run. +
 This allows one to check the difference between runs
 and thus help in debugging what caused the bit-rot or failure in general.
+
 image::https://user-images.githubusercontent.com/32995541/178442403-e15264ca-433a-4bc7-95db-cfadb573db3c.png[]
 =====
 

--- a/{{ cookiecutter.project_slug }}/README.orig.adoc
+++ b/{{ cookiecutter.project_slug }}/README.orig.adoc
@@ -162,7 +162,7 @@ vars:
 
 
 [[tested-distributions]]
-=== 🧪 Tested Distributions
+== 🧪 Tested Distributions
 
 A role may work on different *distributions*, like Red Hat Enterprise Linux (RHEL),
 even though there is no test for this exact distribution.
@@ -222,7 +222,7 @@ even though there is no test for this exact distribution.
 
 
 [[tested-ansible-versions]]
-=== 🧪 Tested Ansible versions
+== 🧪 Tested Ansible versions
 
 The tested ansible versions try to stay equivalent with the
 https://github.com/ansible-collections/community.general#tested-with-ansible[

--- a/{{ cookiecutter.project_slug }}/README.orig.adoc
+++ b/{{ cookiecutter.project_slug }}/README.orig.adoc
@@ -161,6 +161,78 @@ vars:
 ====
 
 
+[[tested-distributions]]
+=== 🧪 Tested Distributions
+
+A role may work on different *distributions*, like Red Hat Enterprise Linux (RHEL),
+even though there is no test for this exact distribution.
+
+|===
+| OS Family | Distribution | Distribution Release Date | Distribution End of Life | Accompanying Docker Image
+
+| RedHat
+| CentOS 7
+| 2014-07
+| 2024-06
+| https://github.com/geerlingguy/docker-centos7-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-centos7-ansible/workflows/Build/badge.svg?branch=master[CI]]
+(https://github.com/geerlingguy/docker-centos7-ansible/issues/18[*,title="CentOS 7 is old"])
+
+| Rocky
+| Rocky Linux 8 (https://www.howtogeek.com/devops/is-rocky-linux-the-new-centos/[RHEL/CentOS 8 in disguise])
+| 2021-06
+| 2029-05
+| https://github.com/geerlingguy/docker-rockylinux8-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-rockylinux8-ansible/workflows/Build/badge.svg?branch=master[CI]]
+
+| RedHat
+| Fedora 35
+| 2021-11
+| 2022-11
+| https://github.com/geerlingguy/docker-fedora35-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-fedora35-ansible/workflows/Build/badge.svg?branch=master[CI]]
+
+| Debian
+| Ubuntu 1604
+| 2016-04
+| 2026-04
+| https://github.com/geerlingguy/docker-ubuntu1604-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-ubuntu1604-ansible/workflows/Build/badge.svg?branch=master[CI]]
+
+| Debian
+| Ubuntu 1804
+| 2018-04
+| 2028-04
+| https://github.com/geerlingguy/docker-ubuntu1804-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-ubuntu1804-ansible/workflows/Build/badge.svg?branch=master[CI]]
+
+| Debian
+| Ubuntu 2004
+| 2021-09
+| 2030-04
+| https://github.com/geerlingguy/docker-ubuntu2004-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-ubuntu2004-ansible/workflows/Build/badge.svg?branch=master[CI]]
+
+| Debian
+| Debian 10
+| 2019-07
+| 2022-08
+| https://github.com/geerlingguy/docker-debian10-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-debian10-ansible/workflows/Build/badge.svg?branch=master[CI]]
+
+| Debian
+| Debian 11
+| 2021-08
+| ?
+| https://github.com/geerlingguy/docker-debian11-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-debian11-ansible/workflows/Build/badge.svg?branch=master[CI]]
+|===
+
+
+[[tested-ansible-versions]]
+=== 🧪 Tested Ansible versions
+
+The tested ansible versions try to stay equivalent with the
+https://github.com/ansible-collections/community.general#tested-with-ansible[
+support pattern of Ansible's `community.general` collection].
+As of writing this is:
+
+* 2.11 (Ansible 4)
+* 2.12 (Ansible 5)
+
+
 [[development]]
 == 📝 Development
 // Badges about Conventions in this Project


### PR DESCRIPTION
Closes #78 

not every role may work on every distribution, so having have had it like before was bad now every role can potentially have it's own table or make remarks in his section on different distributions it's just better all in all

aims to remove yet another reference to the potentially not existing ansible-roles repository