### PR TITLE
chore: install useful/relevant extensions in devcontainer

### DIFF
--- a/{{ cookiecutter.project_slug }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.project_slug }}/.devcontainer/devcontainer.json
@@ -21,9 +21,38 @@
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "bash ./.devcontainer/postCreateCommand.sh"
+  "postCreateCommand": "bash ./.devcontainer/postCreateCommand.sh",
   // Configure tool-specific properties.
-  // "customizations": {},
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        // ## General / GUI ##
+        "eamodio.gitlens",
+        "donjayamanne.githistory",
+        "mhutchie.git-graph",
+        "GitHub.vscode-pull-request-github",
+        "GitHub.vscode-github-actions",
+        "GitHub.github-vscode-theme",
+        "vscode-icons-team.vscode-icons",
+        "bierner.markdown-preview-github-styles",
+        "mutantdino.resourcemonitor",
+        "aaron-bond.better-comments",
+        "Gruntfuggly.todo-tree",
+        "muuvmuuv.vscode-sundial",
+        "WakaTime.vscode-wakatime",
+        "asciidoctor.asciidoctor-vscode",
+        "christian-kohler.path-intellisense",
+        "EditorConfig.EditorConfig",
+
+        // ## Ansible Development ##
+        "donjayamanne.python-extension-pack",
+        "redhat.ansible",
+        "redhat.vscode-yaml",
+        "samuelcolvin.jinjahtml",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  }
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"
 }


### PR DESCRIPTION
Closes #92
tested locally in ansible-role-bootstrap

found out new path (customizations.vscode.extensions) by just typing in vscode as it knows about the structure of devcontainer.json