### PR TITLE
fix: use new molecule-plugins[docker]

### DIFF
--- a/{{ cookiecutter.project_slug }}/tox.ini
+++ b/{{ cookiecutter.project_slug }}/tox.ini
@@ -18,8 +18,12 @@ deps =
     ansible-4: ansible == 4.* # core 2.11 + https://github.com/ansible-community/ansible-build-data/blob/main/4/ansible-4.build
     ansible-5: ansible == 5.* # core 2.12 + https://github.com/ansible-community/ansible-build-data/blob/main/5/ansible-5.build
     ansible-6: ansible == 6.* # core 2.13 + https://github.com/ansible-community/ansible-build-data/blob/main/6/ansible-6.build
-    molecule[docker]
+    ansible-4: molecule == 4.*
     docker == 5.*
+    ansible-{5,6}: molecule == 5.* # molecule v5.0.0 requires ansible-core>=2.12
+    ansible-4: molecule-plugins[docker] == 22.*
+    ansible-{5,6}: molecule-plugins[docker] == 23.* # molecule-plugins v23.4.0 requires ansible-core>=2.12
+    paramiko == 3.*
     ansible-4: ansible-lint == 5.*
     ansible-{5,6}: ansible-lint == 6.* # ansible-lint 6 made ansible 2.12+ a direct dependency
 commands =


### PR DESCRIPTION
fixes a `KeyError: 'docker'` error i experienced on my devcontainer (both laptop and desktop) and which also [happens in CI](https://github.com/JonasPammer/cookiecutter-ansible-role/actions/runs/4828400701/jobs/8602176674?pr=95):

```
   File "/home/runner/work/cookiecutter-ansible-role/cookiecutter-ansible-role/ansible-role-myrole/.tox/py3-ansible-6/lib/python3.11/site-packages/molecule/api.py", line 30, in __getitem__
    return self.__dict__[i]
           ~~~~~~~~~~~~~^^^
KeyError: 'docker'
py3-ansible-6: exit 1 (0.84 seconds) /home/runner/work/cookiecutter-ansible-role/cookiecutter-ansible-role/ansible-role-myrole> molecule destroy pid=8844
  pre-commit: OK (5.13=setup[3.05]+cmd[2.08] seconds)
  py3-ansible-4: OK (208.70=setup[91.06]+cmd[0.74,17.08,2.63,97.19] seconds)
  py3-ansible-5: FAIL code 1 (103.82=setup[102.54]+cmd[0.42,0.85] seconds)
  py3-ansible-6: FAIL code 1 (34.50=setup[33.24]+cmd[0.42,0.84] seconds)
```

first kudo's go to https://github.com/robertdebock/ansible-role-bootstrap/commit/d9a5f51b555f66c65e993aced657254b549142dd +
for completeness: [a link to web archive showing mention of `molecule-plugins` in the official installation docs of molecule v5.0.0](https://web.archive.org/web/20230426130002/https://molecule.readthedocs.io/installation/) as per https://github.com/ansible-community/molecule/pull/3805