### PR TITLE
fix: don't mention docker dep itself

### DIFF
--- a/{{ cookiecutter.project_slug }}/tox.ini
+++ b/{{ cookiecutter.project_slug }}/tox.ini
@@ -19,7 +19,6 @@ deps =
     ansible-5: ansible == 5.* # core 2.12 + https://github.com/ansible-community/ansible-build-data/blob/main/5/ansible-5.build
     ansible-6: ansible == 6.* # core 2.13 + https://github.com/ansible-community/ansible-build-data/blob/main/6/ansible-6.build
     ansible-4: molecule == 4.*
-    docker == 5.*
     ansible-{5,6}: molecule == 5.* # molecule v5.0.0 requires ansible-core>=2.12
     ansible-4: molecule-plugins[docker] == 22.*
     ansible-{5,6}: molecule-plugins[docker] == 23.* # molecule-plugins v23.4.0 requires ansible-core>=2.12


### PR DESCRIPTION
as done in https://github.com/JonasPammer/ansible-role-bootstrap/pull/83
i think the whole reason i started said PR was because I wondered "why cap it at that without reason?".
molecule-plugins[docker] brings the docker dep, with a fitting ">" delimiter which for example brings us https://github.com/docker/docker-py/pull/3116 thus this PR closes #103