### PR TITLE
ci: add "[skip pre-commit.ci]" to ensure renovate automerge isnt blocked

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,6 +28,7 @@
     {
       matchUpdateTypes: ["minor", "patch", "pin", "digest", "pinDigest"],
       automerge: true,
+      commitBody: "[skip pre-commit.ci]",
     },
   ],
   labels: ["kind/dependencies"],

--- a/{{ cookiecutter.project_slug }}/.github/renovate.json5
+++ b/{{ cookiecutter.project_slug }}/.github/renovate.json5
@@ -32,6 +32,7 @@
     {
       matchUpdateTypes: ["minor", "patch", "pin", "digest", "pinDigest"],
       automerge: true,
+      commitBody: "[skip pre-commit.ci]",
     },
   ],
   labels: ["kind/dependencies"],


### PR DESCRIPTION
Closes https://github.com/JonasPammer/cookiecutter-ansible-role/issues/126. Kinda Part of https://github.com/JonasPammer/cookiecutter-ansible-role/pull/138