### PR TITLE
ci: only run github-labeler on push

### DIFF
--- a/.github/workflows/issue-label-manager.yml
+++ b/.github/workflows/issue-label-manager.yml
@@ -2,7 +2,6 @@
 name: create declared labels
 
 "on":
-  issues:
   push:
     branches:
       - master

--- a/{{ cookiecutter.project_slug }}/.github/workflows/issue-label-manager.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/issue-label-manager.yml
@@ -2,7 +2,6 @@
 name: create declared labels
 
 "on":
-  issues:
   push:
     branches:
       - master


### PR DESCRIPTION
Fixes #148