### PR TITLE
ci: change gh-pages deployment source from branch to action

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/gh-pages.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/gh-pages.yml
@@ -20,6 +20,10 @@ jobs:
     permissions:
       contents: write
       pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       ### Setup
       - name: check out the codebase
@@ -98,11 +102,19 @@ jobs:
       ### Deploy README.adoc
       - name: Generate HTML
         run: asciidoctor --backend=html5 --destination-dir docs --out-file index.html README.adoc
+        if: github.ref == 'refs/heads/master'
 
-      - name: Deploy HTML to GitHub Pages (when branch is master).
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+        if: github.ref == 'refs/heads/master'
+
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v2
         with:
-          github_token: "{% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}"
-          publish_branch: gh-pages
-          publish_dir: ./docs/
+          path: "./docs/"
+        if: github.ref == 'refs/heads/master'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
Fixes #111

steps taken from starter template "static":
https://github.com/actions/starter-workflows/blob/main/pages/static.yml