### PR TITLE
feat(ci): add ansible 7, 8 to test matrix

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -33,15 +33,14 @@ name: CI (Lint + Molecule)
         type: choice
         default: "ansible-6"
         options:
-          - ansible-4,ansible-5,ansible-6,ansible-7,ansible-8,ansible-9
+          - ansible-4,ansible-5,ansible-6,ansible-7,ansible-8
           - ansible-4,ansible-5,ansible-6
-          - ansible-7,ansible-8,ansible-9
+          - ansible-7,ansible-8
           - ansible-4
           - ansible-5
           - ansible-6
           - ansible-7
           - ansible-8
-          - ansible-9
   pull_request:
     branches-ignore:
       - renovate/**

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -33,11 +33,15 @@ name: CI (Lint + Molecule)
         type: choice
         default: "ansible-6"
         options:
+          - ansible-4,ansible-5,ansible-6,ansible-7,ansible-8,ansible-9
           - ansible-4,ansible-5,ansible-6
-          - ansible-4,ansible-5
+          - ansible-7,ansible-8,ansible-9
           - ansible-4
           - ansible-5
           - ansible-6
+          - ansible-7
+          - ansible-8
+          - ansible-9
   pull_request:
     branches-ignore:
       - renovate/**

--- a/{{ cookiecutter.project_slug }}/README.orig.adoc
+++ b/{{ cookiecutter.project_slug }}/README.orig.adoc
@@ -257,7 +257,6 @@ As of writing this is:
 * 2.13 (Ansible 6)
 * 2.14 (Ansible 7)
 * 2.15 (Ansible 8)
-* 2.16 (Ansible 9)
 
 
 [[development]]

--- a/{{ cookiecutter.project_slug }}/README.orig.adoc
+++ b/{{ cookiecutter.project_slug }}/README.orig.adoc
@@ -255,6 +255,9 @@ As of writing this is:
 * 2.11 (Ansible 4)
 * 2.12 (Ansible 5)
 * 2.13 (Ansible 6)
+* 2.14 (Ansible 7)
+* 2.15 (Ansible 8)
+* 2.16 (Ansible 9)
 
 
 [[development]]

--- a/{{ cookiecutter.project_slug }}/tox.ini
+++ b/{{ cookiecutter.project_slug }}/tox.ini
@@ -23,12 +23,12 @@ deps =
     ansible-7: ansible == 7.* # core 2.14
     ansible-8: ansible == 8.* # core 2.15
     ansible-4: molecule == 4.*
-    ansible: molecule >= 5 # molecule v5.0.0 requires ansible-core>=2.12
+    ansible-!4: molecule >= 5 # molecule v5.0.0 requires ansible-core>=2.12
     ansible-4: molecule-plugins[docker] == 22.*
-    ansible: molecule-plugins[docker] >= 23 # molecule-plugins v23.4.0 requires ansible-core>=2.12
+    ansible-!4: molecule-plugins[docker] >= 23 # molecule-plugins v23.4.0 requires ansible-core>=2.12
     paramiko == 3.*
     ansible-4: ansible-lint == 5.*
-    ansible: ansible-lint >= 6 # ansible-lint 6 made ansible 2.12+ a direct dependency
+    ansible-!4: ansible-lint >= 6 # ansible-lint 6 made ansible 2.12+ a direct dependency
 commands =
     ansible --version
     molecule destroy

--- a/{{ cookiecutter.project_slug }}/tox.ini
+++ b/{{ cookiecutter.project_slug }}/tox.ini
@@ -24,12 +24,12 @@ deps =
     ansible-8: ansible == 8.* # core 2.15
     ansible-9: ansible == 9.* # core 2.16
     ansible-4: molecule == 4.*
-    ansible: molecule >= 5.* # molecule v5.0.0 requires ansible-core>=2.12
+    ansible: molecule >= 5 # molecule v5.0.0 requires ansible-core>=2.12
     ansible-4: molecule-plugins[docker] == 22.*
-    ansible: molecule-plugins[docker] >= 23.* # molecule-plugins v23.4.0 requires ansible-core>=2.12
+    ansible: molecule-plugins[docker] >= 23 # molecule-plugins v23.4.0 requires ansible-core>=2.12
     paramiko == 3.*
     ansible-4: ansible-lint == 5.*
-    ansible: ansible-lint >= 6.* # ansible-lint 6 made ansible 2.12+ a direct dependency
+    ansible: ansible-lint >= 6 # ansible-lint 6 made ansible 2.12+ a direct dependency
 commands =
     ansible --version
     molecule destroy

--- a/{{ cookiecutter.project_slug }}/tox.ini
+++ b/{{ cookiecutter.project_slug }}/tox.ini
@@ -7,7 +7,7 @@ extend-ignore = E203
 ### Ansible Testing through Molecule ###
 [tox]
 minversion = 4.1.2
-envlist = pre-commit,py{3}-ansible-{4,5,6}
+envlist = pre-commit,py{3}-ansible-{4,5,6,7,8,9}
 
 skipsdist = true
 
@@ -15,16 +15,21 @@ skipsdist = true
 passenv = *
 parallel_show_output = True
 deps =
-    ansible-4: ansible == 4.* # core 2.11 + https://github.com/ansible-community/ansible-build-data/blob/main/4/ansible-4.build
-    ansible-5: ansible == 5.* # core 2.12 + https://github.com/ansible-community/ansible-build-data/blob/main/5/ansible-5.build
-    ansible-6: ansible == 6.* # core 2.13 + https://github.com/ansible-community/ansible-build-data/blob/main/6/ansible-6.build
+    # For information on what included in the the "ansible" package,
+    # see https://github.com/ansible-community/ansible-build-data/blob/main/ (e.g. `/5/ansible-5.build`).
+    ansible-4: ansible == 4.* # core 2.11
+    ansible-5: ansible == 5.* # core 2.12
+    ansible-6: ansible == 6.* # core 2.13
+    ansible-7: ansible == 7.* # core 2.14
+    ansible-8: ansible == 8.* # core 2.15
+    ansible-9: ansible == 9.* # core 2.16
     ansible-4: molecule == 4.*
-    ansible-{5,6}: molecule == 5.* # molecule v5.0.0 requires ansible-core>=2.12
+    ansible: molecule >= 5.* # molecule v5.0.0 requires ansible-core>=2.12
     ansible-4: molecule-plugins[docker] == 22.*
-    ansible-{5,6}: molecule-plugins[docker] == 23.* # molecule-plugins v23.4.0 requires ansible-core>=2.12
+    ansible: molecule-plugins[docker] >= 23.* # molecule-plugins v23.4.0 requires ansible-core>=2.12
     paramiko == 3.*
     ansible-4: ansible-lint == 5.*
-    ansible-{5,6}: ansible-lint == 6.* # ansible-lint 6 made ansible 2.12+ a direct dependency
+    ansible: ansible-lint >= 6.* # ansible-lint 6 made ansible 2.12+ a direct dependency
 commands =
     ansible --version
     molecule destroy

--- a/{{ cookiecutter.project_slug }}/tox.ini
+++ b/{{ cookiecutter.project_slug }}/tox.ini
@@ -7,7 +7,7 @@ extend-ignore = E203
 ### Ansible Testing through Molecule ###
 [tox]
 minversion = 4.1.2
-envlist = pre-commit,py{3}-ansible-{4,5,6,7,8,9}
+envlist = pre-commit,py{3}-ansible-{4,5,6,7,8}
 
 skipsdist = true
 
@@ -22,7 +22,6 @@ deps =
     ansible-6: ansible == 6.* # core 2.13
     ansible-7: ansible == 7.* # core 2.14
     ansible-8: ansible == 8.* # core 2.15
-    ansible-9: ansible == 9.* # core 2.16
     ansible-4: molecule == 4.*
     ansible: molecule >= 5 # molecule v5.0.0 requires ansible-core>=2.12
     ansible-4: molecule-plugins[docker] == 22.*


### PR DESCRIPTION
as per https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix, minimum controller python version still is 3.9 at least for the documented 2.15

i couldn't see anything breaking in interest for me in molecule.
i hope my changed tox `deps` declaration works as i expect it to (i.e. "if ansible-4, use moleucle == 4.*, otherwhise use >= 5.*")
also changed to >= to be always up to date. bit rot checked by CI anyways


Closes #115