### PR TITLE
refactor: remove EOL distributions from automatic tests

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -15,17 +15,13 @@ name: CI (Lint + Molecule)
         type: choice
         default: "ubuntu2204"
         options:
-          - ubuntu1804
           - ubuntu2004
           - ubuntu2204
-          - debian10
           - debian11
+          - debian12
           - rockylinux8
           - rockylinux9
-          - fedora35
-          - fedora36
-          - fedora37
-          - fedora38
+          - fedora39
           - ALL
       ansible_version:
         description: "Select Ansible Versions to run"
@@ -102,23 +98,19 @@ jobs:
     name: Molecule
     runs-on: ubuntu-latest
     strategy:
-      # half length of matrix's distro list:
-      max-parallel: 6
+      # half length of matrix's distro list / most important:
+      max-parallel: 4
       matrix:
         distro:
           # ensure diversity in first half:
-          - ubuntu1804
           - ubuntu2204
-          - debian11
+          - debian12
           - rockylinux9
-          - fedora35
-          - fedora38
+          - fedora39
           # other:
-          - ubuntu2004
-          - debian10
           - rockylinux8
-          - fedora36
-          - fedora37
+          - ubuntu2004
+          - debian11
 
     env:
       {% raw -%}

--- a/{{ cookiecutter.project_slug }}/DEVELOPMENT.adoc
+++ b/{{ cookiecutter.project_slug }}/DEVELOPMENT.adoc
@@ -86,7 +86,7 @@ ERROR:   py3-ansible-9: commands failed
 [subs="quotes"]
 ----
 $ *docker ps*
-#30e9b8d59cdf#   geerlingguy/docker-debian10-ansible:latest   "/lib/systemd/systemd"   8 minutes ago   Up 8 minutes                                                                                                    instance-py3-ansible-9
+#30e9b8d59cdf#   geerlingguy/docker-debian12-ansible:latest   "/lib/systemd/systemd"   8 minutes ago   Up 8 minutes                                                                                                    instance-py3-ansible-9
 ----
 
 3. Get into a bash Shell of the container, and do your debugging:

--- a/{{ cookiecutter.project_slug }}/README.orig.adoc
+++ b/{{ cookiecutter.project_slug }}/README.orig.adoc
@@ -167,9 +167,12 @@ vars:
 A role may work on different *distributions*, like Red Hat Enterprise Linux (RHEL),
 even though there is no test for this exact distribution.
 
+// good reference for what to follow -- most starred and pinned project of geerlingguy:
+// https://github.com/geerlingguy/ansible-role-docker/blob/master/.github/workflows/ci.yml
 |===
 | OS Family | Distribution | Distribution Release Date | Distribution End of Life | Accompanying Docker Image
 
+// https://endoflife.date/rocky-linux
 | Rocky
 | Rocky Linux 8 (https://www.howtogeek.com/devops/is-rocky-linux-the-new-centos/[RHEL/CentOS 8 in disguise])
 | 2021-06
@@ -182,65 +185,39 @@ even though there is no test for this exact distribution.
 | 2032-05
 | https://github.com/geerlingguy/docker-rockylinux9-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-rockylinux9-ansible/workflows/Build/badge.svg?branch=master[CI]]
 
+// https://endoflife.date/fedora (13 Months)
 | RedHat
-| Fedora 35
-| 2021-11
-| 2022-11
-| https://github.com/geerlingguy/docker-fedora35-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-fedora35-ansible/workflows/Build/badge.svg?branch=master[CI]]
+| Fedora 39
+| 2023-11
+| 2024-12
+| https://github.com/geerlingguy/docker-fedora39-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-fedora39-ansible/workflows/Build/badge.svg?branch=master[CI]]
 
-| RedHat
-| Fedora 36
-| 2022-05
-| 2023-05
-| https://github.com/geerlingguy/docker-fedora36-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-fedora36-ansible/workflows/Build/badge.svg?branch=master[CI]]
-
-| RedHat
-| Fedora 37
-| 2022-11
-| 2023-12
-| https://github.com/geerlingguy/docker-fedora37-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-fedora37-ansible/workflows/Build/badge.svg?branch=master[CI]]
-
-| RedHat
-| Fedora 38
-| 2023-03
-| 2024-05
-| https://github.com/geerlingguy/docker-fedora38-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-fedora38-ansible/workflows/Build/badge.svg?branch=master[CI]]
-
+// https://ubuntu.com/about/release-cycle
 | Debian
-| Ubuntu 1604
-| 2016-04
-| 2026-04
-| https://github.com/geerlingguy/docker-ubuntu1604-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-ubuntu1604-ansible/workflows/Build/badge.svg?branch=master[CI]]
-
-| Debian
-| Ubuntu 1804
-| 2018-04
-| 2028-04
-| https://github.com/geerlingguy/docker-ubuntu1804-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-ubuntu1804-ansible/workflows/Build/badge.svg?branch=master[CI]]
-
-| Debian
-| Ubuntu 2004
+| Ubuntu 20.04 LTS
 | 2021-04
-| 2030-04
+| 2025-04
 | https://github.com/geerlingguy/docker-ubuntu2004-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-ubuntu2004-ansible/workflows/Build/badge.svg?branch=master[CI]]
 
 | Debian
-| Ubuntu 2204
+| Ubuntu 22.04 LTS
 | 2022-04
-| 2032-04
+| 2027-04
 | https://github.com/geerlingguy/docker-ubuntu2204-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-ubuntu2204-ansible/workflows/Build/badge.svg?branch=master[CI]]
 
-| Debian
-| Debian 10
-| 2019-07
-| 2022-08
-| https://github.com/geerlingguy/docker-debian10-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-debian10-ansible/workflows/Build/badge.svg?branch=master[CI]]
-
+// https://wiki.debian.org/DebianReleases
+// https://wiki.debian.org/LTS
 | Debian
 | Debian 11
 | 2021-08
-| 2024-07~
+| 2024-06 (2026-06 LTS)
 | https://github.com/geerlingguy/docker-debian11-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-debian11-ansible/workflows/Build/badge.svg?branch=master[CI]]
+
+| Debian
+| Debian 12
+| 2023-06
+| 2026-06 (2028-06 LTS)
+| https://github.com/geerlingguy/docker-debian12-ansible/actions?query=workflow%3ABuild[image:https://github.com/geerlingguy/docker-debian12-ansible/workflows/Build/badge.svg?branch=master[CI]]
 |===
 
 

--- a/{{ cookiecutter.project_slug }}/meta/main.yml
+++ b/{{ cookiecutter.project_slug }}/meta/main.yml
@@ -12,22 +12,17 @@ galaxy_info:
     # note: text after "actively tested: " represent the docker image name
     - name: EL # (Enterprise Linux)
       versions:
-        - "8" # actively tested: rockylinux8
         - "9" # actively tested: rockylinux9
     - name: Fedora
       versions:
-        - "35" # actively tested: fedora35
-        - "36" # actively tested: fedora36
-        - "37" # actively tested: fedora37
         - "38" # actively tested: fedora38
+        - "39" # actively tested: fedora39
     - name: Debian
       versions:
-        - buster # actively tested: debian10
         - bullseye # actively tested: debian11
+        - bookworm # actively tested: debian12
     - name: Ubuntu
       versions:
-        - xenial # actively tested: ubuntu1604
-        - bionic # actively tested: ubuntu1804
         - focal # actively tested: ubuntu2004
         - jammy # actively tested: ubuntu2204
 

--- a/{{ cookiecutter.project_slug }}/molecule/default/molecule.yml
+++ b/{{ cookiecutter.project_slug }}/molecule/default/molecule.yml
@@ -11,8 +11,8 @@ driver:
   name: docker
 platforms:
   # service-enabled Docker image by geerlingguy
-  - name: instance-${TOX_ENVNAME}-${MOLECULE_DISTRO:-debian10}
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian10}-ansible:latest"
+  - name: instance-${TOX_ENVNAME}-${MOLECULE_DISTRO:-debian12}
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw


### PR DESCRIPTION
debian10/fedora38 theoretically still have some months until EOL, but I dont use them and want to save myself hastle from doing this again for at least like 1 year (fedora39 EOL date)

manually passing old and still working geerlingguy container images still work, so this is no major / breaking change.