### PR TITLE
 ci: configure Renovate to automerge all action updates

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/renovate.json5
+++ b/{{ cookiecutter.project_slug }}/.github/renovate.json5
@@ -28,6 +28,7 @@
     {
       matchDepTypes: ["action"],
       labels: ["kind/dependencies", "kind/infrastructure"],
+      automerge: true,
     },
     {
       schedule: ["every 3 months on the first day of the month"],

--- a/{{ cookiecutter.project_slug }}/.github/workflows/gh-pages.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/gh-pages.yml
@@ -3,8 +3,6 @@ name: build self-contained READMEs
 
 "on":
   push:
-    branches-ignore:
-      - renovate/**
 
 permissions:
   contents: read
@@ -87,12 +85,16 @@ jobs:
           pre-commit run --files README.md SECURITY.md || true
           pre-commit run --files README.md SECURITY.md || true
 
+      - id: is_renovate
+        run: echo "::set-output name=is_renovate::$( [[ ${GITHUB_REF#refs/heads/} != renovate/* ]] && echo false || echo true )"
+
       - name: Commit generated files.
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "{% raw %}${{ env.FIRST_LINE_OF_HEAD_COMMIT_MESSAGE }}{% endraw %}\n{% raw %}${{ github.sha }}{% endraw %}"
           file_pattern: README.adoc README.md SECURITY.md
           disable_globbing: true
+        if: steps.is_renovate.outputs.is_renovate == 'false'
 
       ### (Deploy README.adoc)
       - name: Generate HTML


### PR DESCRIPTION
... which basically is everything renovate does for an ansible role, except ansible-galaxy requriements.yml but not many roles (not any of mine of yet) have anything in there with specific version

happens on base schedule (yearly)

removing the global branches-ignore from gh-pages CI is meant to ensure renovate doesn't break it when it updates something within said workflow file (or at least, the tasks that come up until to it)

POC: https://github.com/JonasPammer/ansible-role-bootstrap/commit/5b5bb8fa3f13f3e3b80f83f064b7c46406f3f9e2