### PR TITLE
fix(ci): remove galaxy_info.standalone

### DIFF
--- a/{{ cookiecutter.project_slug }}/meta/main.yml
+++ b/{{ cookiecutter.project_slug }}/meta/main.yml
@@ -2,7 +2,6 @@
 galaxy_info:
   role_name: "{{ cookiecutter.role_name }}"
   description: "An ansible role for {{ cookiecutter.project_short_purpose }}."
-  standalone: true
 
   author: "{{ cookiecutter.galaxy_name }}"
   license: "{{ cookiecutter.open_source_license }}"


### PR DESCRIPTION
https://github.com/JonasPammer/ansible-role-bootstrap/compare/3.0.3+1...3.0.3+2

successfull now:
https://github.com/JonasPammer/ansible-role-bootstrap/actions/runs/7949377098/job/21700461814

```
==== PARAMETERS ====
importer username: JonasPammer
matched user: JonasPammer id:18797
github_user: JonasPammer
github_repo: ansible-role-bootstrap
github_reference: None
alternate_clone_url: None
alternate_namespace_name: None
alternate_role_name: None

==== CHECK FOR MATCHING ROLE(S) ====
user:JonasPammer repo:ansible-role-bootstrap matched existing role jonaspammer.bootstrap id:34595

===== CLONING REPO =====
cloning https://github.com/JonasPammer/ansible-role-bootstrap ...

===== GIT ATTRIBUTES =====
github_reference(branch): master
github_commit: 3cf13c2e83121796b0ac53b1354d86b5c05d25b3
github_commit_message: fix(ci): remove galaxy_info.standalone
899796171d3954062bf313af79f2cdbcf946066f
github_commit_date: 2024-02-18T13:31:58+00:00

===== LOADING ROLE =====
Importing with galaxy-importer 0.4.19
Determined role name to be bootstrap
Linting role bootstrap via ansible-lint...
ansible-role-bootstrap/molecule/resources/debug.yml:2:3: syntax-check[specific]: 'ansible.builtin.copy' is not a valid attribute for a Play
...ansible-lint run complete
Legacy role loading complete

===== PROCESSING LOADER RESULTS ====
enumerated role name bootstrap

===== COMPUTING ROLE VERSIONS ====
adding new version from tag: 3.0.3+1
adding new version from tag: 3.0.3+2
tag: 1.0.0 version: 1.0.0
tag: 2.0.0 version: 2.0.0
tag: 2.1.0 version: 2.1.0
tag: 3.0.0 version: 3.0.0
tag: 3.0.1 version: 3.0.1
tag: 3.0.2 version: 3.0.2
tag: 3.0.2+1 version: 3.0.2+1
tag: 3.0.3 version: 3.0.3
tag: 3.0.3+1 version: 3.0.3+1
tag: 3.0.3+2 version: 3.0.3+2

==== SAVING ROLE ====

Import completed
```